### PR TITLE
feat(core): add compability for send with android 12 and lower

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ tmp2/
 *.temp
 
 # Application specific
+.dashbeam-*
 .sendme-*
 .keystore.jks
 

--- a/engine/native/src/history.rs
+++ b/engine/native/src/history.rs
@@ -20,7 +20,7 @@ pub const MAX_RECORDS: usize = 500;
 pub const MAX_FILE_NAMES: usize = 20;
 
 /// Prefix `storage::create_recv_store` gives every partial-receive directory.
-const PARTIAL_STORE_PREFIX: &str = ".sendme-recv-";
+const PARTIAL_STORE_PREFIX: &str = crate::storage::RECV_DIR_PREFIX;
 
 /// BLAKE3 hash, hex encoded.
 const PARTIAL_STORE_HASH_LEN: usize = 64;
@@ -519,7 +519,7 @@ mod tests {
         "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 
     fn partial_dir(root: &Path, hash: &str) -> PathBuf {
-        let dir = root.join(format!(".sendme-recv-{hash}"));
+        let dir = root.join(format!(".dashbeam-recv-{hash}"));
         std::fs::create_dir_all(&dir).expect("create partial");
         dir
     }
@@ -550,15 +550,15 @@ mod tests {
 
     #[test]
     fn partial_store_hash_reads_a_well_formed_dir_name() {
-        let path = PathBuf::from(format!("/tmp/.sendme-recv-{HASH_A}"));
+        let path = PathBuf::from(format!("/tmp/.dashbeam-recv-{HASH_A}"));
         assert_eq!(partial_store_hash(&path).as_deref(), Some(HASH_A));
     }
 
     #[test]
     fn partial_store_hash_rejects_a_foreign_dir_name() {
         assert!(partial_store_hash(Path::new("/tmp/important-documents")).is_none());
-        assert!(partial_store_hash(Path::new("/tmp/.sendme-recv-short")).is_none());
-        assert!(partial_store_hash(Path::new("/tmp/.sendme-send-abc")).is_none());
+        assert!(partial_store_hash(Path::new("/tmp/.dashbeam-recv-short")).is_none());
+        assert!(partial_store_hash(Path::new("/tmp/.dashbeam-send-abc")).is_none());
     }
 
     #[test]

--- a/engine/native/src/storage.rs
+++ b/engine/native/src/storage.rs
@@ -13,9 +13,17 @@ use std::path::{Path, PathBuf};
 /// `std::env::temp_dir()`, so tests and non-Tauri consumers keep working.
 pub static TEMP_DIR: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
 
+/// Directory name prefix of every send-side blob store.
+pub const SEND_DIR_PREFIX: &str = ".dashbeam-send-";
+/// Directory name prefix of every partial-receive blob store.
+pub const RECV_DIR_PREFIX: &str = ".dashbeam-recv-";
+/// Prefixes older builds used. Never created any more; the shell still sweeps
+/// them at launch so an upgrade leaves nothing behind in the temp dir.
+pub const LEGACY_DIR_PREFIXES: [&str; 2] = [".sendme-send-", ".sendme-recv-"];
+
 pub fn new_send_blobs_dir() -> PathBuf {
     let suffix = rand::rng().random::<[u8; 16]>();
-    temp_dir().join(format!(".sendme-send-{}", HEXLOWER.encode(&suffix)))
+    temp_dir().join(format!("{SEND_DIR_PREFIX}{}", HEXLOWER.encode(&suffix)))
 }
 
 pub async fn create_send_store(dir: &Path) -> anyhow::Result<FsStore> {
@@ -28,7 +36,7 @@ pub async fn create_send_store(dir: &Path) -> anyhow::Result<FsStore> {
 }
 
 pub async fn create_recv_store(hash_hex: &str) -> anyhow::Result<(FsStore, PathBuf)> {
-    let dir_name = format!(".sendme-recv-{}", hash_hex);
+    let dir_name = format!("{RECV_DIR_PREFIX}{hash_hex}");
     let path = temp_dir().join(dir_name);
     let store = FsStore::load(&path)
         .await

--- a/engine/native/src/storage.rs
+++ b/engine/native/src/storage.rs
@@ -37,9 +37,5 @@ pub fn recv_cleanup_guard(path: PathBuf) -> AutoCleanupDir {
 }
 
 pub fn temp_dir() -> PathBuf {
-   if cfg!(test) {
-    std::env::temp_dir()
-   } else {
-    TEMP_DIR.get().cloned().unwrap()
-   }
+    TEMP_DIR.get().cloned().unwrap_or_else(|| std::env::temp_dir().join("DashBeam"))
 }

--- a/engine/native/src/storage.rs
+++ b/engine/native/src/storage.rs
@@ -7,9 +7,11 @@ use iroh_blobs::store::fs::FsStore;
 use rand::RngExt;
 use std::path::{Path, PathBuf};
 
+pub static TEMP_DIR: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();  
+
 pub fn new_send_blobs_dir() -> PathBuf {
     let suffix = rand::rng().random::<[u8; 16]>();
-    std::env::temp_dir().join(format!(".sendme-send-{}", HEXLOWER.encode(&suffix)))
+    temp_dir().join(format!(".sendme-send-{}", HEXLOWER.encode(&suffix)))
 }
 
 pub async fn create_send_store(dir: &Path) -> anyhow::Result<FsStore> {
@@ -23,7 +25,7 @@ pub async fn create_send_store(dir: &Path) -> anyhow::Result<FsStore> {
 
 pub async fn create_recv_store(hash_hex: &str) -> anyhow::Result<(FsStore, PathBuf)> {
     let dir_name = format!(".sendme-recv-{}", hash_hex);
-    let path = std::env::temp_dir().join(dir_name);
+    let path = temp_dir().join(dir_name);
     let store = FsStore::load(&path)
         .await
         .with_context(|| format!("failed to load recv store at {}", path.display()))?;
@@ -32,4 +34,8 @@ pub async fn create_recv_store(hash_hex: &str) -> anyhow::Result<(FsStore, PathB
 
 pub fn recv_cleanup_guard(path: PathBuf) -> AutoCleanupDir {
     AutoCleanupDir::new(path)
+}
+
+pub fn temp_dir() -> PathBuf {
+    TEMP_DIR.get().cloned().unwrap()
 }

--- a/engine/native/src/storage.rs
+++ b/engine/native/src/storage.rs
@@ -7,7 +7,11 @@ use iroh_blobs::store::fs::FsStore;
 use rand::RngExt;
 use std::path::{Path, PathBuf};
 
-pub static TEMP_DIR: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();  
+/// Root for every blob store this crate creates. Set once by the shell
+/// (Android points it at the app cache dir, where `std::env::temp_dir()` is
+/// not writable before Android 13). Left unset, [`temp_dir`] falls back to
+/// `std::env::temp_dir()`, so tests and non-Tauri consumers keep working.
+pub static TEMP_DIR: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
 
 pub fn new_send_blobs_dir() -> PathBuf {
     let suffix = rand::rng().random::<[u8; 16]>();
@@ -37,5 +41,5 @@ pub fn recv_cleanup_guard(path: PathBuf) -> AutoCleanupDir {
 }
 
 pub fn temp_dir() -> PathBuf {
-    TEMP_DIR.get().cloned().unwrap_or_else(|| std::env::temp_dir().join("DashBeam"))
+    TEMP_DIR.get().cloned().unwrap_or_else(std::env::temp_dir)
 }

--- a/engine/native/src/storage.rs
+++ b/engine/native/src/storage.rs
@@ -37,5 +37,9 @@ pub fn recv_cleanup_guard(path: PathBuf) -> AutoCleanupDir {
 }
 
 pub fn temp_dir() -> PathBuf {
+   if cfg!(test) {
+    std::env::temp_dir()
+   } else {
     TEMP_DIR.get().cloned().unwrap()
+   }
 }

--- a/engine/tests/test_cleanup.rs
+++ b/engine/tests/test_cleanup.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 /// Where the receiver keeps blobs for this ticket — the path comes from its hash.
 fn receiver_temp_dir(ticket: &str) -> std::path::PathBuf {
     let parsed = iroh_blobs::ticket::BlobTicket::from_str(ticket).unwrap();
-    std::env::temp_dir().join(format!(
+    native::storage::temp_dir().join(format!(
         ".sendme-recv-{}",
         data_encoding::HEXLOWER.encode(parsed.hash().as_bytes())
     ))

--- a/engine/tests/test_cleanup.rs
+++ b/engine/tests/test_cleanup.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 fn receiver_temp_dir(ticket: &str) -> std::path::PathBuf {
     let parsed = iroh_blobs::ticket::BlobTicket::from_str(ticket).unwrap();
     native::storage::temp_dir().join(format!(
-        ".sendme-recv-{}",
+        ".dashbeam-recv-{}",
         data_encoding::HEXLOWER.encode(parsed.hash().as_bytes())
     ))
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -433,7 +433,7 @@ pub async fn stop_sharing(state: State<'_, AppStateMutex>) -> Result<(), String>
         }
 
         #[cfg(target_os = "android")]
-        std::fs::remove_dir_all(&share._path);
+        let _ = std::fs::remove_dir_all(&share._path);
     }
 
     #[cfg(any(desktop, target_os = "android"))]
@@ -483,7 +483,8 @@ pub async fn receive_file(
         let stale_hash = state.lock().await.last_cancelled_recv_hash.take();
         if let Some(stale_hash) = stale_hash {
             if &stale_hash != new_hash {
-                let stale_dir = std::env::temp_dir().join(format!(".sendme-recv-{}", stale_hash));
+                let stale_dir =
+                    engine::storage::temp_dir().join(format!(".sendme-recv-{}", stale_hash));
                 if stale_dir.exists() {
                     if let Err(e) = tokio::fs::remove_dir_all(&stale_dir).await {
                         tracing::warn!("Failed to remove stale partial recv store: {}", e);
@@ -1843,7 +1844,12 @@ mod tests {
             .duration_since(UNIX_EPOCH)
             .expect("clock should be after unix epoch")
             .as_nanos();
-        std::env::temp_dir().join(format!("{}-{}-{}.txt", name_prefix, std::process::id(), ts))
+        engine::storage::temp_dir().join(format!(
+            "{}-{}-{}.txt",
+            name_prefix,
+            std::process::id(),
+            ts
+        ))
     }
 
     /// Locks the seam with the frontend's `useAppSettingStore`, which writes
@@ -1973,7 +1979,7 @@ pub async fn delete_transfer_record(
 ) -> Result<(), String> {
     let removed = history.delete(&id).map_err(|e| e.to_string())?;
     if let Some(record) = removed {
-        engine::reclaim_partial(&record, &std::env::temp_dir());
+        engine::reclaim_partial(&record, &engine::storage::temp_dir());
     }
     Ok(())
 }
@@ -1983,7 +1989,7 @@ pub async fn clear_transfer_history(
     history: State<'_, Arc<TransferHistoryStore>>,
 ) -> Result<(), String> {
     let removed = history.clear().map_err(|e| e.to_string())?;
-    let temp_dir = std::env::temp_dir();
+    let temp_dir = engine::storage::temp_dir();
     for record in &removed {
         engine::reclaim_partial(record, &temp_dir);
     }
@@ -2011,7 +2017,7 @@ pub async fn get_transfer_temp_data(
     };
 
     let path = PathBuf::from(path);
-    if !engine::is_reclaimable_partial(&path, &std::env::temp_dir()) {
+    if !engine::is_reclaimable_partial(&path, &engine::storage::temp_dir()) {
         return Ok(TransferTempData {
             exists: false,
             size_bytes: 0,
@@ -2049,7 +2055,7 @@ pub async fn clear_transfer_temp_data(
         }
     }
 
-    engine::reclaim_partial(&record, &std::env::temp_dir());
+    engine::reclaim_partial(&record, &engine::storage::temp_dir());
     history
         .update(&id, |r| r.resumable_store_path = None)
         .map_err(|e| e.to_string())?;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -483,8 +483,8 @@ pub async fn receive_file(
         let stale_hash = state.lock().await.last_cancelled_recv_hash.take();
         if let Some(stale_hash) = stale_hash {
             if &stale_hash != new_hash {
-                let stale_dir =
-                    engine::storage::temp_dir().join(format!(".sendme-recv-{}", stale_hash));
+                let stale_dir = engine::storage::temp_dir()
+                    .join(format!("{}{stale_hash}", engine::storage::RECV_DIR_PREFIX));
                 if stale_dir.exists() {
                     if let Err(e) = tokio::fs::remove_dir_all(&stale_dir).await {
                         tracing::warn!("Failed to remove stale partial recv store: {}", e);

--- a/src-tauri/src/history.rs
+++ b/src-tauri/src/history.rs
@@ -328,7 +328,7 @@ fn parse_file_names(payload: &str) -> Option<Vec<String>> {
 
 /// Where a partial receive for `hash` would live.
 pub fn partial_store_path_for(hash: &str) -> PathBuf {
-    std::env::temp_dir().join(format!(".sendme-recv-{hash}"))
+    engine::storage::temp_dir().join(format!(".sendme-recv-{hash}"))
 }
 
 #[cfg(test)]

--- a/src-tauri/src/history.rs
+++ b/src-tauri/src/history.rs
@@ -328,7 +328,7 @@ fn parse_file_names(payload: &str) -> Option<Vec<String>> {
 
 /// Where a partial receive for `hash` would live.
 pub fn partial_store_path_for(hash: &str) -> PathBuf {
-    engine::storage::temp_dir().join(format!(".sendme-recv-{hash}"))
+    engine::storage::temp_dir().join(format!("{}{hash}", engine::storage::RECV_DIR_PREFIX))
 }
 
 #[cfg(test)]
@@ -489,7 +489,7 @@ mod tests {
         let (store, emitter) = recorder(
             &dir,
             TransferDirection::Receive,
-            receive_context("/tmp/.sendme-recv-hash"),
+            receive_context("/tmp/.dashbeam-recv-hash"),
         );
 
         emitter.emit_event("receive-started").expect("emit");
@@ -523,7 +523,7 @@ mod tests {
         let (store, emitter) = recorder(
             &dir,
             TransferDirection::Receive,
-            receive_context("/tmp/.sendme-recv-hash"),
+            receive_context("/tmp/.dashbeam-recv-hash"),
         );
 
         emitter.emit_event("receive-started").expect("emit");
@@ -537,7 +537,7 @@ mod tests {
         assert_eq!(row.status, TransferStatus::InProgress);
         assert_eq!(
             row.resumable_store_path.as_deref(),
-            Some("/tmp/.sendme-recv-hash"),
+            Some("/tmp/.dashbeam-recv-hash"),
             "the pointer written at open is what makes the partial reclaimable"
         );
 
@@ -554,7 +554,7 @@ mod tests {
         let (store, emitter) = recorder(
             &dir,
             TransferDirection::Receive,
-            receive_context("/tmp/.sendme-recv-hash"),
+            receive_context("/tmp/.dashbeam-recv-hash"),
         );
 
         emitter.emit_event("receive-started").expect("emit");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -210,20 +210,22 @@ pub fn run() {
             respond_nearby_invite,
         ])
         .setup(|app| {
-            let _ = engine::storage::TEMP_DIR.set({
-                #[cfg(target_os = "android")]
-                let path = app.path().app_cache_dir().map(|f| f.join("DashBeamTemp")).unwrap_or_else(|_|
-                    {
-                        tracing::error!("Could not resolve app_cache_dir; using invalid placeholder path");
-                        std::path::PathBuf::from("/__dashbeam_invalid_cache_dir__")
-                    }
-                );
-                #[cfg(not(target_os = "android"))]
-                let path = std::env::temp_dir().join("DashBeam");
-
-                path
-            });
             init_logging(app.handle());
+            // Before Android 13 `std::env::temp_dir()` is `/data/local/tmp`,
+            // which the app cannot write, so blob stores go in the app cache
+            // dir instead. That is also where `TMPDIR` points on 13+, so
+            // partial receives from earlier builds stay resumable. Desktop
+            // keeps the unmodified `std::env::temp_dir()` fallback for the
+            // same reason. Must run before `setup_common`, which scans it.
+            #[cfg(target_os = "android")]
+            match app.path().app_cache_dir() {
+                Ok(dir) => {
+                    let _ = engine::storage::TEMP_DIR.set(dir);
+                }
+                Err(e) => tracing::error!(
+                    "Could not resolve app_cache_dir; falling back to std::env::temp_dir(): {e}"
+                ),
+            }
             setup_common(app);
             #[cfg(desktop)]
             tray::set_background_on_close(commands::load_persisted_minimize_to_tray(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -30,7 +30,10 @@ use tauri::{Emitter as _, Manager as _, RunEvent};
 
 /// Clean up any orphaned .sendme-* directories from previous runs
 fn cleanup_orphaned_directories() {
-    let scan_dirs = vec![std::env::current_dir().ok(), Some(std::env::temp_dir())];
+    let scan_dirs = vec![
+        std::env::current_dir().ok(),
+        Some(engine::storage::temp_dir()),
+    ];
     for base_dir in scan_dirs.into_iter().flatten() {
         if let Ok(entries) = fs::read_dir(&base_dir) {
             for entry in entries.flatten() {
@@ -207,6 +210,19 @@ pub fn run() {
             respond_nearby_invite,
         ])
         .setup(|app| {
+            let _ = engine::storage::TEMP_DIR.set({
+                #[cfg(target_os = "android")]
+                let path = app.path().app_cache_dir().map(|f| f.join("DashBeamTemp")).unwrap_or_else(|_|
+                    {
+                        tracing::error!("Could not resolve app_cache_dir; using invalid placeholder path");
+                        std::path::PathBuf::from("/__dashbeam_invalid_cache_dir__")
+                    }
+                );
+                #[cfg(not(target_os = "android"))]
+                let path = std::env::temp_dir().join("DashBeam");
+
+                path
+            });
             init_logging(app.handle());
             setup_common(app);
             #[cfg(desktop)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,7 +28,9 @@ use std::sync::Arc;
 
 use tauri::{Emitter as _, Manager as _, RunEvent};
 
-/// Clean up any orphaned .sendme-* directories from previous runs
+/// Clean up any orphaned blob store directories from previous runs. Also
+/// sweeps the `.sendme-*` names older builds used, so an upgrade leaves
+/// nothing behind.
 fn cleanup_orphaned_directories() {
     let scan_dirs = vec![
         std::env::current_dir().ok(),
@@ -38,9 +40,12 @@ fn cleanup_orphaned_directories() {
         if let Ok(entries) = fs::read_dir(&base_dir) {
             for entry in entries.flatten() {
                 if let Some(name) = entry.file_name().to_str() {
-                    if (name.starts_with(".sendme-send-") || name.starts_with(".sendme-recv-"))
-                        && entry.path().is_dir()
-                    {
+                    let ours = name.starts_with(engine::storage::SEND_DIR_PREFIX)
+                        || name.starts_with(engine::storage::RECV_DIR_PREFIX)
+                        || engine::storage::LEGACY_DIR_PREFIXES
+                            .iter()
+                            .any(|p| name.starts_with(p));
+                    if ours && entry.path().is_dir() {
                         if let Err(e) = fs::remove_dir_all(&entry.path()) {
                             tracing::warn!("Failed to clean up orphaned directory {}: {}", name, e);
                         }


### PR DESCRIPTION
## Description
Added compability with android 12 and lower for temp folder by put temp folder to app folder
<!-- Briefly describe what this PR does -->

## Checklist

- [x] PR title follows Conventional Commits (`type(scope): description`)
- [x] I have run **`pnpm lint`** before raising this PR
- [x] I have run **`pnpm format`** before raising this PR
