### PR TITLE
type(feat): Enable authenticated private relays to have a higher rate limit

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -340,6 +340,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
+dependencies = [
+ "cargo-lock",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,6 +367,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "cargo-lock"
+version = "11.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50524592e6bfbb1bf6f94e8184a786f637faeaf1cf37bbe65502b9a2c5c48939"
+dependencies = [
+ "semver",
+ "serde",
+ "toml",
+ "url",
 ]
 
 [[package]]
@@ -730,7 +751,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -821,7 +842,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -981,7 +1002,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1551,7 +1572,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -2031,6 +2052,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "iroh-services"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a88cd95fbd20abd9eadc4df91c722915dc943412b964e915f35b0b0a46a1fd"
+dependencies = [
+ "anyhow",
+ "base64",
+ "built",
+ "bytes",
+ "data-encoding",
+ "derive_more",
+ "ed25519-dalek",
+ "futures-buffered",
+ "getrandom 0.4.2",
+ "iroh",
+ "iroh-metrics",
+ "iroh-tickets",
+ "irpc",
+ "irpc-iroh",
+ "n0-error",
+ "n0-future",
+ "portmapper",
+ "postcard",
+ "rand",
+ "rcan",
+ "serde",
+ "serde_json",
+ "strum",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "iroh-tickets"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2089,6 +2146,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "irpc-iroh"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2342daed629b312f61e57e452b0750a59da162f261b97f260a6354de61d4fb0e"
+dependencies = [
+ "getrandom 0.3.4",
+ "iroh",
+ "iroh-base",
+ "irpc",
+ "n0-error",
+ "n0-future",
+ "postcard",
+ "serde",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2566,7 +2641,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
@@ -2611,7 +2686,7 @@ checksum = "bde7a5d5102f1cff03d482240f0ed20551661f63663620f4b26112ed751165e9"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -2622,7 +2697,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2837,7 +2912,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3216,6 +3291,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcan"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12a624a4a4742f8c6e58fba99712e606cea0491b76f5b2345f06af5802101027"
+dependencies = [
+ "anyhow",
+ "derive_more",
+ "ed25519-dalek",
+ "hex",
+ "n0-future",
+ "postcard",
+ "serde",
+ "serdect",
+]
+
+[[package]]
 name = "rcgen"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3398,7 +3489,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3456,7 +3547,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3477,7 +3568,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3569,7 +3660,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3583,6 +3674,10 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "send_wrapper"
@@ -3625,6 +3720,7 @@ dependencies = [
  "getrandom 0.3.4",
  "iroh",
  "iroh-blobs",
+ "iroh-services",
  "n0-future",
  "rustls",
  "serde",
@@ -3700,6 +3796,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -4061,7 +4166,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4257,10 +4362,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.4",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -4272,19 +4401,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 0.7.14",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow",
+ "winnow 1.0.4",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -4376,6 +4511,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4385,12 +4530,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -4478,6 +4626,7 @@ checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -4704,7 +4853,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5128,6 +5277,12 @@ checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "winreg"

--- a/engine/native/src/node.rs
+++ b/engine/native/src/node.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use anyhow::Context;
 use iroh::endpoint::{
-    presets, AfterHandshakeOutcome, Connection, Endpoint, EndpointHooks, RelayMode, Side,
+    AfterHandshakeOutcome, Connection, Endpoint, EndpointHooks, RelayMode, Side,
 };
 use iroh::protocol::{AcceptError, ProtocolHandler, Router};
 use iroh::address_lookup::pkarr::{PkarrPublisher, PkarrResolver};
@@ -2229,8 +2229,10 @@ async fn build_runtime(
             pkarr_relay_url,
             dns_origin,
         } => {
-            let mut builder =
-                protocol::with_system_ca_if_custom(Endpoint::builder(presets::Minimal), custom_infra)
+            let mut builder = protocol::with_system_ca_if_custom(
+                    protocol::endpoint_builder(identity.secret_key.clone(), &relay_mode, false)?,
+                    custom_infra,
+                )
                     .address_lookup(PkarrPublisher::builder(pkarr_relay_url.clone()))
                     .address_lookup(PkarrResolver::builder(pkarr_relay_url.clone()));
             if let Some(origin) = dns_origin {
@@ -2239,14 +2241,15 @@ async fn build_runtime(
             builder
         }
         DiscoveryModeOption::Default => {
-            protocol::with_system_ca_if_custom(Endpoint::builder(presets::N0), custom_infra)
+            protocol::with_system_ca_if_custom(
+                protocol::endpoint_builder(identity.secret_key.clone(), &relay_mode, true)?,
+                custom_infra,
+            )
                 .address_lookup(PkarrPublisher::n0_dns())
         }
     };
 
     let endpoint = builder
-        .secret_key(identity.secret_key.clone())
-        .relay_mode(relay_mode.clone())
         .hooks(hook)
         .alpns(vec![CONTROL_ALPN.to_vec()])
         .bind()

--- a/engine/native/src/receive.rs
+++ b/engine/native/src/receive.rs
@@ -1,10 +1,8 @@
 use protocol::{
     download_to_store, get_or_create_secret, AppHandle, DiscoveryModeOption, ReceiveOptions,
 };
-use iroh::endpoint::presets;
 use iroh::{
     address_lookup::{dns::DnsAddressLookup, pkarr::PkarrResolver},
-    Endpoint,
 };
 use iroh_blobs::ticket::BlobTicket;
 use std::str::FromStr;
@@ -33,11 +31,13 @@ pub async fn download(
 
     let custom_infra =
         protocol::uses_custom_infra(&options.discovery_mode, &options.relay_mode);
+    let relay_mode: iroh::endpoint::RelayMode = options.relay_mode.clone().into();
     let mut builder =
-        protocol::with_system_ca_if_custom(Endpoint::builder(presets::Minimal), custom_infra)
-            .alpns(vec![])
-            .secret_key(secret_key)
-            .relay_mode(options.relay_mode.clone().into());
+        protocol::with_system_ca_if_custom(
+            protocol::endpoint_builder(secret_key, &relay_mode, false)?,
+            custom_infra,
+        )
+            .alpns(vec![]);
 
     if ticket.addr().relay_urls().count() == 0 && ticket.addr().ip_addrs().count() == 0 {
         builder = match &options.discovery_mode {

--- a/engine/native/src/send.rs
+++ b/engine/native/src/send.rs
@@ -3,8 +3,7 @@ use std::path::PathBuf;
 use protocol::{
     run_share_session, AppHandle, DiscoveryModeOption, FileMetadata, SendOptions, METADATA_ALPN,
 };
-use iroh::endpoint::presets;
-use iroh::{address_lookup::pkarr::PkarrPublisher, endpoint::RelayMode, Endpoint};
+use iroh::{address_lookup::pkarr::PkarrPublisher, endpoint::RelayMode};
 use iroh_blobs::{
     provider::events::{ConnectMode, EventMask, EventSender, RequestMode},
     BlobsProtocol,
@@ -41,16 +40,12 @@ pub async fn start_share_items(
     // the control endpoint is online, or the relay rejects duplicate endpoint ids.
     let secret_key = get_or_create_secret()?;
     let relay_mode: RelayMode = options.relay_mode.clone().into();
-    let builder = match &options.discovery_mode {
-        DiscoveryModeOption::Custom { .. } => Endpoint::builder(presets::Minimal),
-        DiscoveryModeOption::Default => Endpoint::builder(presets::N0),
-    };
+    let default_discovery = matches!(options.discovery_mode, DiscoveryModeOption::Default);
+    let builder = protocol::endpoint_builder(secret_key, &relay_mode, default_discovery)?;
     let custom_infra =
         protocol::uses_custom_infra(&options.discovery_mode, &options.relay_mode);
     let mut builder = protocol::with_system_ca_if_custom(builder, custom_infra)
-        .alpns(vec![iroh_blobs::ALPN.to_vec(), METADATA_ALPN.to_vec()])
-        .secret_key(secret_key)
-        .relay_mode(relay_mode.clone());
+        .alpns(vec![iroh_blobs::ALPN.to_vec(), METADATA_ALPN.to_vec()]);
 
     match &options.discovery_mode {
         // Self-hosted discovery: publish our home relay to the custom pkarr relay so

--- a/engine/protocol/Cargo.toml
+++ b/engine/protocol/Cargo.toml
@@ -21,6 +21,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.108"
 tracing = "0.1.40"
 url = "2"
+iroh-services = "1.0.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 iroh-blobs = { version = "0.103" }

--- a/engine/protocol/src/discovery.rs
+++ b/engine/protocol/src/discovery.rs
@@ -165,8 +165,7 @@ pub async fn verify_discovery(
     arg: DiscoveryConfigArg,
 ) -> Result<VerifyDiscoveryResponse, String> {
     use iroh::address_lookup::pkarr::PkarrPublisher;
-    use iroh::endpoint::{presets, RelayMode};
-    use iroh::Endpoint;
+    use iroh::endpoint::RelayMode;
 
     let mode = build_discovery_mode(Some(arg))?;
     let DiscoveryModeOption::Custom {
@@ -181,11 +180,10 @@ pub async fn verify_discovery(
     // Custom discovery always needs OS trust for private-CA pkarr HTTPS.
     // DotTolerant wrapping also covers the default n0 relay probe path on Windows.
     let endpoint = crate::tls_config::with_system_ca_if_custom(
-        Endpoint::builder(presets::Minimal),
+        crate::endpoint_builder(secret_key, &RelayMode::Default, false)
+            .map_err(|e| e.to_string())?,
         true,
     )
-    .secret_key(secret_key)
-    .relay_mode(RelayMode::Default)
     .address_lookup(PkarrPublisher::builder(pkarr_relay_url.clone()))
     .bind()
     .await

--- a/engine/protocol/src/endpoint.rs
+++ b/engine/protocol/src/endpoint.rs
@@ -1,0 +1,69 @@
+//! Shared iroh endpoint construction.
+
+use iroh::{
+    endpoint::{presets, Builder, RelayMode},
+    Endpoint, SecretKey,
+};
+
+const IROH_SERVICES_RELAYS: [&str; 4] = [
+    "https://e3qdnz19n5p4tnh6b.euc1.relay.iroh-svc.com/",
+    "https://e3qdnz19n5p4tnh6b.use1.relay.iroh-svc.com/",
+    "https://e3qdnz19n5p4tnh6b.usw1.relay.iroh-svc.com/",
+    "https://e3qdnz19n5p4tnh6b.aps1.relay.iroh-svc.com/",
+];
+
+const IROH_SERVICES_API_SECRET: &str =
+    "servicesaaqizynrq3pdxtwxnnrlcxg5rpezbcpthntqlwpxc5oren2557x6nkgjlxfzhaykym52alh56n2vwg5b5sme5k2r3ez6rbuyevxwsx2cgeaa";
+
+/// Build an endpoint with the configured iroh-services relays for the app's
+/// default relay mode. Explicit custom and disabled modes retain their prior
+/// behavior.
+///
+/// `default_discovery` controls whether the n0 address lookup installed by the
+/// preset is retained. Self-hosted discovery callers clear it before adding
+/// their own lookup services.
+pub fn endpoint_builder(
+    secret_key: SecretKey,
+    relay_mode: &RelayMode,
+    default_discovery: bool,
+) -> anyhow::Result<Builder> {
+    let builder = match relay_mode {
+        RelayMode::Default => {
+            // The preset derives relay authorization from the endpoint key, so
+            // the key must be supplied before the preset is built.
+            let preset = iroh_services::preset()
+                .relays(IROH_SERVICES_RELAYS)?
+                .api_secret_from_str(IROH_SERVICES_API_SECRET)?
+                .secret_key(secret_key)
+                .build()?;
+            Endpoint::builder(preset)
+        }
+        _ => {
+            let builder = if default_discovery {
+                Endpoint::builder(presets::N0)
+            } else {
+                Endpoint::builder(presets::Minimal)
+            };
+            builder
+                .secret_key(secret_key)
+                .relay_mode(relay_mode.clone())
+        }
+    };
+
+    Ok(if default_discovery {
+        builder
+    } else {
+        builder.clear_address_lookup()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn iroh_services_configuration_is_valid() {
+        endpoint_builder(SecretKey::generate(), &RelayMode::Default, true)
+            .expect("iroh-services relays and API secret should be valid");
+    }
+}

--- a/engine/protocol/src/lib.rs
+++ b/engine/protocol/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod control;
 pub mod discovery;
+pub mod endpoint;
 pub mod identity;
 pub mod nearby;
 pub mod pairing;
@@ -38,6 +39,7 @@ pub use discovery::{
     build_discovery_mode, parse_dns_origin, parse_pkarr_relay_url, DiscoveryConfigArg,
     VerifyDiscoveryResponse,
 };
+pub use endpoint::endpoint_builder;
 #[cfg(not(target_arch = "wasm32"))]
 pub use discovery::verify_discovery;
 pub use tls_config::{uses_custom_infra, with_system_ca_if_custom};

--- a/engine/protocol/src/receive.rs
+++ b/engine/protocol/src/receive.rs
@@ -5,7 +5,6 @@ use crate::progress::{
 };
 use crate::time_compat::{sleep, timeout, Duration, Instant};
 use crate::types::{get_or_create_secret, AppHandle, DiscoveryModeOption, FileMetadata, ReceiveOptions};
-use iroh::endpoint::presets;
 #[cfg(not(target_arch = "wasm32"))]
 use iroh::{
     address_lookup::{dns::DnsAddressLookup, pkarr::PkarrResolver},
@@ -269,17 +268,14 @@ pub async fn fetch_metadata(
     let secret_key = get_or_create_secret()?;
 
     let discovery_mode = options.discovery_mode.clone();
-    let builder = match &discovery_mode {
-        DiscoveryModeOption::Custom { .. } => Endpoint::builder(presets::Minimal),
-        DiscoveryModeOption::Default => Endpoint::builder(presets::N0),
-    };
+    let relay_mode: iroh::endpoint::RelayMode = options.relay_mode.clone().into();
+    let default_discovery = matches!(discovery_mode, DiscoveryModeOption::Default);
+    let builder = crate::endpoint_builder(secret_key, &relay_mode, default_discovery)?;
     let custom_infra =
         crate::tls_config::uses_custom_infra(&discovery_mode, &options.relay_mode);
     let mut builder = crate::tls_config::with_system_ca_if_custom(builder, custom_infra)
         // METADATA_ALPN only to indicate a metadata fetch
-        .alpns(vec![METADATA_ALPN.to_vec()])
-        .secret_key(secret_key)
-        .relay_mode(options.relay_mode.into());
+        .alpns(vec![METADATA_ALPN.to_vec()]);
 
     #[cfg(not(target_arch = "wasm32"))]
     {

--- a/engine/protocol/src/relay.rs
+++ b/engine/protocol/src/relay.rs
@@ -1,6 +1,6 @@
 use crate::time_compat::{sleep, timeout, Duration, Instant};
 use crate::types::{get_or_create_secret, RelayModeOption};
-use iroh::{endpoint::presets, Endpoint, Watcher};
+use iroh::{Endpoint, Watcher};
 use serde::{Deserialize, Serialize};
 use std::net::IpAddr;
 use std::str::FromStr;
@@ -137,7 +137,9 @@ pub struct VerifyRelaysResponse {
 }
 
 pub fn is_public_relay_url(url: &str) -> bool {
-    url.contains("relay.n0.iroh.link") || url.contains(".iroh.link")
+    url.contains("relay.n0.iroh.link")
+        || url.contains(".iroh.link")
+        || url.contains(".relay.iroh-svc.com")
 }
 
 fn connected_home_relay_url(endpoint: &Endpoint) -> Option<String> {
@@ -176,10 +178,11 @@ async fn probe_relay_mode(relay_mode: RelayModeOption) -> Result<Option<String>,
 
     let secret_key = get_or_create_secret().map_err(|e| e.to_string())?;
     let custom_infra = matches!(relay_mode, RelayModeOption::Custom { .. });
-    let endpoint =
-        crate::tls_config::with_system_ca_if_custom(Endpoint::builder(presets::Minimal), custom_infra)
-            .secret_key(secret_key)
-            .relay_mode(relay_mode.into())
+    let relay_mode: iroh::endpoint::RelayMode = relay_mode.into();
+    let endpoint = crate::tls_config::with_system_ca_if_custom(
+        crate::endpoint_builder(secret_key, &relay_mode, false).map_err(|e| e.to_string())?,
+        custom_infra,
+    )
             .bind()
             .await
             .map_err(|e| format!("Failed to bind endpoint: {e}"))?;
@@ -341,11 +344,12 @@ pub async fn verify_relays(relay: RelayConfigArg) -> Result<VerifyRelaysResponse
 
     let secret_key = get_or_create_secret().map_err(|e| e.to_string())?;
     let custom_infra = matches!(relay_mode, RelayModeOption::Custom { .. });
+    let relay_mode: iroh::endpoint::RelayMode = relay_mode.into();
 
-    let endpoint =
-        crate::tls_config::with_system_ca_if_custom(Endpoint::builder(presets::Minimal), custom_infra)
-            .secret_key(secret_key)
-            .relay_mode(relay_mode.into())
+    let endpoint = crate::tls_config::with_system_ca_if_custom(
+        crate::endpoint_builder(secret_key, &relay_mode, false).map_err(|e| e.to_string())?,
+        custom_infra,
+    )
             .bind()
             .await
             .map_err(|e| format!("Failed to bind endpoint: {e}"))?;

--- a/engine/tests/test_pairing.rs
+++ b/engine/tests/test_pairing.rs
@@ -158,9 +158,7 @@ fn pairing_ticket_encodes_bare_endpoint_id_for_iroh_services_relay() {
         v: 1,
         kind: PairingTicket::KIND.to_string(),
         endpoint_id: endpoint_id.clone(),
-        relay_url: Some(
-            "https://e3qdnz19n5p4tnh6b.use1.relay.iroh-svc.com/".to_string(),
-        ),
+        relay_url: Some("https://e3qdnz19n5p4tnh6b.use1.relay.iroh-svc.com/".to_string()),
     };
     let encoded = ticket.encode().expect("encode");
     assert_eq!(encoded, endpoint_id);

--- a/engine/tests/test_pairing.rs
+++ b/engine/tests/test_pairing.rs
@@ -152,6 +152,21 @@ fn pairing_ticket_encodes_bare_endpoint_id_for_public_relay() {
 }
 
 #[test]
+fn pairing_ticket_encodes_bare_endpoint_id_for_iroh_services_relay() {
+    let endpoint_id = generated_endpoint_id();
+    let ticket = PairingTicket {
+        v: 1,
+        kind: PairingTicket::KIND.to_string(),
+        endpoint_id: endpoint_id.clone(),
+        relay_url: Some(
+            "https://e3qdnz19n5p4tnh6b.use1.relay.iroh-svc.com/".to_string(),
+        ),
+    };
+    let encoded = ticket.encode().expect("encode");
+    assert_eq!(encoded, endpoint_id);
+}
+
+#[test]
 fn pairing_ticket_encode_rejects_invalid_endpoint_id() {
     let ticket = PairingTicket {
         v: 1,

--- a/engine/wasm-io/src/receive.rs
+++ b/engine/wasm-io/src/receive.rs
@@ -2,8 +2,6 @@ use protocol::{
     download_to_store, get_or_create_secret, uses_custom_infra, with_system_ca_if_custom,
     AppHandle, ReceiveOptions,
 };
-use iroh::endpoint::presets;
-use iroh::Endpoint;
 use iroh_blobs::ticket::BlobTicket;
 use std::str::FromStr;
 
@@ -21,11 +19,9 @@ pub async fn download_files(
     let secret_key = get_or_create_secret()?;
 
     let custom_infra = uses_custom_infra(&options.discovery_mode, &options.relay_mode);
+    let relay_mode: iroh::endpoint::RelayMode = options.relay_mode.clone().into();
     let builder = with_system_ca_if_custom(
-        Endpoint::builder(presets::Minimal)
-            .alpns(vec![])
-            .secret_key(secret_key)
-            .relay_mode(options.relay_mode.clone().into()),
+        protocol::endpoint_builder(secret_key, &relay_mode, false)?.alpns(vec![]),
         custom_infra,
     );
 

--- a/engine/wasm-io/src/send.rs
+++ b/engine/wasm-io/src/send.rs
@@ -2,8 +2,7 @@ use protocol::{
     get_or_create_secret, run_share_session, uses_custom_infra, with_system_ca_if_custom,
     AddrInfoOptions, AppHandle, FileMetadata, SendOptions, METADATA_ALPN,
 };
-use iroh::endpoint::presets;
-use iroh::{endpoint::RelayMode, Endpoint};
+use iroh::endpoint::RelayMode;
 use iroh_blobs::{
     provider::events::{ConnectMode, EventMask, EventSender, RequestMode},
     BlobsProtocol,
@@ -27,10 +26,8 @@ pub async fn start_share_bytes(
 
     let custom_infra = uses_custom_infra(&options.discovery_mode, &options.relay_mode);
     let builder = with_system_ca_if_custom(
-        Endpoint::builder(presets::N0)
-            .alpns(vec![iroh_blobs::ALPN.to_vec(), METADATA_ALPN.to_vec()])
-            .secret_key(secret_key)
-            .relay_mode(relay_mode.clone()),
+        protocol::endpoint_builder(secret_key, &relay_mode, true)?
+            .alpns(vec![iroh_blobs::ALPN.to_vec(), METADATA_ALPN.to_vec()]),
         custom_infra,
     );
 
@@ -92,10 +89,8 @@ pub async fn start_share_items_bytes(
 
     let custom_infra = uses_custom_infra(&options.discovery_mode, &options.relay_mode);
     let builder = with_system_ca_if_custom(
-        Endpoint::builder(presets::N0)
-            .alpns(vec![iroh_blobs::ALPN.to_vec(), METADATA_ALPN.to_vec()])
-            .secret_key(secret_key)
-            .relay_mode(relay_mode.clone()),
+        protocol::endpoint_builder(secret_key, &relay_mode, true)?
+            .alpns(vec![iroh_blobs::ALPN.to_vec(), METADATA_ALPN.to_vec()]),
         custom_infra,
     );
 

--- a/frontend/src/components/animate-ui/primitives/effects/highlight.tsx
+++ b/frontend/src/components/animate-ui/primitives/effects/highlight.tsx
@@ -44,8 +44,7 @@ type HighlightContextType<T extends string> = {
 
 const HighlightContext = React.createContext<
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	HighlightContextType<any> | undefined
->(undefined)
+	HighlightContextType<any> | undefined>(undefined)
 
 function useHighlight<T extends string>(): HighlightContextType<T> {
 	const context = React.useContext(HighlightContext)

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -765,6 +765,9 @@ name = "built"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
+dependencies = [
+ "cargo-lock",
+]
 
 [[package]]
 name = "bumpalo"
@@ -831,6 +834,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "cargo-lock"
+version = "11.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50524592e6bfbb1bf6f94e8184a786f637faeaf1cf37bbe65502b9a2c5c48939"
+dependencies = [
+ "semver",
+ "serde",
+ "toml 1.1.2+spec-1.1.0",
+ "url",
 ]
 
 [[package]]
@@ -1527,7 +1542,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1675,7 +1690,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2002,7 +2017,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2446,7 +2461,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
 ]
 
@@ -3755,6 +3770,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "iroh-services"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a88cd95fbd20abd9eadc4df91c722915dc943412b964e915f35b0b0a46a1fd"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "built",
+ "bytes",
+ "data-encoding",
+ "derive_more 2.1.1",
+ "ed25519-dalek",
+ "futures-buffered",
+ "getrandom 0.4.3",
+ "iroh",
+ "iroh-metrics",
+ "iroh-tickets",
+ "irpc",
+ "irpc-iroh",
+ "n0-error",
+ "n0-future",
+ "portmapper",
+ "postcard",
+ "rand 0.10.2",
+ "rcan",
+ "serde",
+ "serde_json",
+ "strum",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "iroh-tickets"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3813,6 +3864,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "irpc-iroh"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2342daed629b312f61e57e452b0750a59da162f261b97f260a6354de61d4fb0e"
+dependencies = [
+ "getrandom 0.3.4",
+ "iroh",
+ "iroh-base",
+ "irpc",
+ "n0-error",
+ "n0-future",
+ "postcard",
+ "serde",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4739,7 +4808,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5981,7 +6050,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6237,6 +6306,22 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rcan"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12a624a4a4742f8c6e58fba99712e606cea0491b76f5b2345f06af5802101027"
+dependencies = [
+ "anyhow",
+ "derive_more 2.1.1",
+ "ed25519-dalek",
+ "hex",
+ "n0-future",
+ "postcard",
+ "serde",
+ "serdect",
 ]
 
 [[package]]
@@ -6500,7 +6585,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6559,7 +6644,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6703,7 +6788,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6799,6 +6884,7 @@ dependencies = [
  "getrandom 0.3.4",
  "iroh",
  "iroh-blobs",
+ "iroh-services",
  "n0-future",
  "rustls",
  "serde",
@@ -8034,7 +8120,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8496,6 +8582,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8505,12 +8601,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -9093,7 +9192,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/wasm-bridge/Cargo.lock
+++ b/wasm-bridge/Cargo.lock
@@ -284,6 +284,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
+dependencies = [
+ "cargo-lock",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,6 +311,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "cargo-lock"
+version = "11.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50524592e6bfbb1bf6f94e8184a786f637faeaf1cf37bbe65502b9a2c5c48939"
+dependencies = [
+ "semver",
+ "serde",
+ "toml",
+ "url",
 ]
 
 [[package]]
@@ -1740,6 +1761,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "iroh-services"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a88cd95fbd20abd9eadc4df91c722915dc943412b964e915f35b0b0a46a1fd"
+dependencies = [
+ "anyhow",
+ "base64",
+ "built",
+ "bytes",
+ "data-encoding",
+ "derive_more",
+ "ed25519-dalek",
+ "futures-buffered",
+ "getrandom 0.4.3",
+ "iroh",
+ "iroh-metrics",
+ "iroh-tickets",
+ "irpc",
+ "irpc-iroh",
+ "n0-error",
+ "n0-future",
+ "portmapper",
+ "postcard",
+ "rand",
+ "rcan",
+ "serde",
+ "serde_json",
+ "strum",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "iroh-tickets"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1798,6 +1855,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "irpc-iroh"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2342daed629b312f61e57e452b0750a59da162f261b97f260a6354de61d4fb0e"
+dependencies = [
+ "getrandom 0.3.4",
+ "iroh",
+ "iroh-base",
+ "irpc",
+ "n0-error",
+ "n0-future",
+ "postcard",
+ "serde",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2822,6 +2897,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcan"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12a624a4a4742f8c6e58fba99712e606cea0491b76f5b2345f06af5802101027"
+dependencies = [
+ "anyhow",
+ "derive_more",
+ "ed25519-dalek",
+ "hex",
+ "n0-future",
+ "postcard",
+ "serde",
+ "serdect",
+]
+
+[[package]]
 name = "rcgen"
 version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3157,6 +3248,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "send_wrapper"
@@ -3175,6 +3270,7 @@ dependencies = [
  "getrandom 0.3.4",
  "iroh",
  "iroh-blobs",
+ "iroh-services",
  "n0-future",
  "rustls",
  "serde",
@@ -3250,6 +3346,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -3714,6 +3819,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3736,12 +3856,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -3833,6 +3959,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3842,12 +3978,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -3923,6 +4062,7 @@ checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 

--- a/wasm-bridge/src/lib.rs
+++ b/wasm-bridge/src/lib.rs
@@ -374,10 +374,13 @@ pub async fn get_relay_status(relay_json: Option<String>) -> Result<String, JsVa
 /// Bind a relay-only iroh endpoint and return its node id (smoke test).
 #[wasm_bindgen]
 pub async fn smoke_test_endpoint() -> Result<String, JsValue> {
-    use iroh::endpoint::presets;
-    use iroh::Endpoint;
+    use iroh::endpoint::RelayMode;
 
-    let endpoint = with_system_ca_if_custom(Endpoint::builder(presets::N0), false)
+    let endpoint = with_system_ca_if_custom(
+        protocol::endpoint_builder(iroh::SecretKey::generate(), &RelayMode::Default, true)
+            .map_err(js_err)?,
+        false,
+    )
         .bind()
         .await
         .map_err(|e| JsValue::from_str(&format!("endpoint bind failed: {e}")))?;


### PR DESCRIPTION
## Description

This PR enables private authenticated relays which have higher rate limits than the public relays for use in Dashbeam. This default relay is managed by the n0.computer team, the same as the public relays, but with higher rate limits and better monitoring capabilities because traffic is not mixed in with all other iroh traffic.

## Checklist

- [ ] PR title follows Conventional Commits (`type(scope): description`)
- [x] I have run **`pnpm lint`** before raising this PR
- [x] I have run **`pnpm format`** before raising this PR
